### PR TITLE
feat(mr-diff): mark viewed + advance to next file in all-files view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gitlab Extended",
-  "version": "1.6",
+  "version": "1.7",
   "description": "Extend GitLab with some useful features",
   "content_scripts": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-extended",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/scripts/mr-diff.ts
+++ b/src/scripts/mr-diff.ts
@@ -4,7 +4,7 @@
 #                 Adapted from                   #
 # https://github.com/JulienZD/GitLab-MR-AutoNext #
 #                                                #
-################################################## 
+##################################################
 */
 
 declare global {
@@ -13,11 +13,278 @@ declare global {
   }
 }
 
+let viewedShortcutSetup = false;
+
 const getElementByQuerySelector = <TElement extends HTMLElement>(
   selector: string,
 ) => {
   const element = document.querySelector(selector) as TElement;
   return element;
+};
+
+const isFileByFileMode = () =>
+  getElementByQuerySelector<HTMLInputElement>('[data-testid="file-by-file"]')
+    ?.checked;
+
+// The old Vue diffs app uses data-testid="fileReviewCheckbox",
+// the new rapid diffs UI uses data-viewed-checkbox
+const VIEWED_CHECKBOX_SELECTOR =
+  '[data-testid="fileReviewCheckbox"], [data-viewed-checkbox]';
+
+const findMarkAsViewedCheckbox = () => {
+  return getElementByQuerySelector<HTMLInputElement>(VIEWED_CHECKBOX_SELECTOR);
+};
+
+const findAllMarkAsViewedCheckboxes = () =>
+  Array.from(
+    document.querySelectorAll<HTMLInputElement>(VIEWED_CHECKBOX_SELECTOR),
+  );
+
+const isTypingContext = (element: Element | null) => {
+  if (!element) {
+    return false;
+  }
+  if (element.tagName === "TEXTAREA") {
+    return true;
+  }
+  if (element.tagName === "INPUT") {
+    return (element as HTMLInputElement).type !== "checkbox";
+  }
+  return (element as HTMLElement).isContentEditable;
+};
+
+const markViewedInSingleFileMode = () => {
+  const checkbox = findMarkAsViewedCheckbox();
+
+  if (!checkbox) {
+    return;
+  }
+
+  checkbox.setAttribute("checked", "checked");
+  checkbox.dispatchEvent(new Event("change"));
+};
+
+const getStickyHeaderHeight = () =>
+  document.querySelector(".merge-request-sticky-header")?.getBoundingClientRect()
+    .height ?? 0;
+
+interface DiffUi {
+  checkboxSelector: string;
+  fileSelector: string;
+  // null: rely on GitLab's own scroll-margin CSS (rapid diffs);
+  // a number: set it as an inline scroll-margin-top (old Vue UI)
+  stickyOffset: () => number | null;
+}
+
+const RAPID_DIFFS_UI: DiffUi = {
+  checkboxSelector: "[data-viewed-checkbox]",
+  fileSelector: '[data-testid="rd-diff-file"]',
+  stickyOffset: () => null,
+};
+
+const OLD_DIFFS_UI: DiffUi = {
+  checkboxSelector: '[data-testid="fileReviewCheckbox"]',
+  fileSelector: ".diff-file",
+  stickyOffset: getStickyHeaderHeight,
+};
+
+const findUnviewedFiles = (ui: DiffUi) =>
+  Array.from(
+    document.querySelectorAll<HTMLInputElement>(ui.checkboxSelector),
+  )
+    .filter((checkbox) => !checkbox.checked)
+    .flatMap((checkbox) => {
+      const file = checkbox.closest<HTMLElement>(ui.fileSelector);
+      return file ? [{ checkbox, file }] : [];
+    });
+
+// Increments on every `v` press so pending scrolls from a previous press
+// can detect they're stale (quick consecutive presses would otherwise
+// ping-pong between targets)
+let advanceGeneration = 0;
+
+// Both diffs UIs load files in batches and re-render on changes, so we always
+// look up the current state of the DOM instead of remembering positions, and
+// never rely on focus (GitLab re-renders silently drop it).
+const markViewedAndAdvance = (ui: DiffUi) => {
+  const generation = ++advanceGeneration;
+  const unviewedFiles = findUnviewedFiles(ui);
+
+  // Always mark the first unviewed file on the page (canonical top-down
+  // review order), regardless of the current scroll position
+  const current = unviewedFiles[0];
+  if (!current) {
+    return;
+  }
+
+  // Decide where to scroll BEFORE clicking: collapsing the current file
+  // shifts the whole layout up, so viewport positions measured afterwards
+  // are unreliable. DOM order is stable.
+  const next = unviewedFiles[1];
+
+  // The next file's DOM node may get replaced when the current one collapses,
+  // so remember its stable identity to re-resolve it at scroll time
+  const nextFileId = next?.file.id;
+  const nextFilePath = next?.file.getAttribute("data-path");
+
+  const resolveNextFile = () => {
+    if (next && next.file.isConnected) {
+      return next.file;
+    }
+    if (nextFileId) {
+      const byId = document.getElementById(nextFileId);
+      if (byId) {
+        return byId;
+      }
+    }
+    if (nextFilePath) {
+      return document.querySelector<HTMLElement>(
+        `${ui.fileSelector}[data-path="${CSS.escape(nextFilePath)}"]`,
+      );
+    }
+    return null;
+  };
+
+  const scrollFileToTop = (file: HTMLElement, behavior: ScrollBehavior) => {
+    // scrollIntoView works regardless of which element is the scroll
+    // container (the window, or an inner panel div); scroll-margin-top
+    // keeps the file header out from under the sticky MR header
+    const stickyOffset = ui.stickyOffset();
+    if (stickyOffset !== null) {
+      file.style.scrollMarginTop = `${stickyOffset}px`;
+    }
+    file.scrollIntoView({ behavior, block: "start" });
+  };
+
+  current.checkbox.click();
+
+  if (!next) {
+    return;
+  }
+
+  // If the user scrolls on their own (wheel, touch, scrollbar drag, or
+  // keyboard), they've taken over — don't fight them with a corrective scroll
+  let userTookOver = false;
+  const scrollKeys = [
+    "ArrowDown",
+    "ArrowUp",
+    "PageDown",
+    "PageUp",
+    "Home",
+    "End",
+    " ",
+  ];
+  const onUserInput = (event: Event) => {
+    if (
+      event instanceof KeyboardEvent &&
+      !scrollKeys.includes(event.key)
+    ) {
+      return;
+    }
+    userTookOver = true;
+  };
+  const userInputEvents = ["wheel", "touchmove", "mousedown", "keydown"];
+  for (const type of userInputEvents) {
+    window.addEventListener(type, onUserInput, { capture: true, passive: true });
+  }
+  const stopWatchingUserInput = () => {
+    for (const type of userInputEvents) {
+      window.removeEventListener(type, onUserInput, { capture: true });
+    }
+  };
+
+  // Marking a file as viewed collapses it, so wait for the layout to settle
+  setTimeout(() => {
+    const target = resolveNextFile();
+    if (!target || generation !== advanceGeneration) {
+      stopWatchingUserInput();
+      return;
+    }
+    scrollFileToTop(target, "smooth");
+
+    // The layout can keep shifting while the smooth scroll runs (collapse
+    // animation, files loading in batches), which can strand the scroll
+    // mid-way — correct the position once things have settled
+    setTimeout(() => {
+      stopWatchingUserInput();
+      if (userTookOver || generation !== advanceGeneration) {
+        return;
+      }
+      const settledTarget = resolveNextFile();
+      if (!settledTarget) {
+        return;
+      }
+      const expectedTop =
+        parseFloat(getComputedStyle(settledTarget).scrollMarginTop) || 0;
+      const offBy = Math.abs(
+        settledTarget.getBoundingClientRect().top - expectedTop,
+      );
+      if (offBy > 40) {
+        scrollFileToTop(settledTarget, "auto");
+      }
+    }, 800);
+  }, 200);
+};
+
+const setupViewedShortcut = () => {
+  if (viewedShortcutSetup) {
+    return;
+  }
+  viewedShortcutSetup = true;
+
+  // Both diffs UIs natively bind `v` (MR_TOGGLE_REVIEW), which toggles the
+  // "viewed" state of whatever GitLab considers the current file — that
+  // fights with our own toggling and advancing (mark + immediate unmark).
+  // Capture the event before GitLab's document-level Mousetrap handler sees
+  // it and handle it ourselves. Mousetrap listens for both keydown and
+  // keypress, so suppress both.
+  const handleAllFilesShortcut = (event: KeyboardEvent) => {
+    if (event.key !== "v") {
+      return;
+    }
+
+    if (isTypingContext(document.activeElement)) {
+      return;
+    }
+
+    if (isFileByFileMode()) {
+      // handled by the legacy keyup listener below
+      return;
+    }
+
+    const ui = document.querySelector("[data-viewed-checkbox]")
+      ? RAPID_DIFFS_UI
+      : document.querySelector('[data-testid="fileReviewCheckbox"]')
+        ? OLD_DIFFS_UI
+        : null;
+
+    if (!ui) {
+      return;
+    }
+
+    event.stopPropagation();
+
+    if (event.type === "keydown") {
+      markViewedAndAdvance(ui);
+    }
+  };
+
+  window.addEventListener("keydown", handleAllFilesShortcut, true);
+  window.addEventListener("keypress", handleAllFilesShortcut, true);
+
+  window.addEventListener("keyup", (event) => {
+    if (event.key !== "v") {
+      return;
+    }
+
+    if (isTypingContext(document.activeElement)) {
+      return;
+    }
+
+    if (isFileByFileMode()) {
+      markViewedInSingleFileMode();
+    }
+  });
 };
 
 const setupAutoNext = () => {
@@ -58,12 +325,6 @@ const setupAutoNext = () => {
     }
   });
 
-  const findMarkAsViewedCheckbox = () => {
-    return getElementByQuerySelector<HTMLInputElement>(
-      '[data-testid="fileReviewCheckbox"]',
-    );
-  };
-
   const setupCheckboxListener = () => {
     const checkbox = findMarkAsViewedCheckbox();
     if (!checkbox) {
@@ -78,35 +339,12 @@ const setupAutoNext = () => {
   });
 
   setupCheckboxListener();
-
-  window.addEventListener("keyup", (event) => {
-    if (event.key !== "v") {
-      return;
-    }
-
-    if (
-      document.activeElement?.tagName === "INPUT" ||
-      document.activeElement?.tagName === "TEXTAREA"
-    ) {
-      return;
-    }
-
-    const checkbox = findMarkAsViewedCheckbox();
-
-    if (!checkbox) {
-      return;
-    }
-
-    checkbox.setAttribute("checked", "checked");
-    checkbox.dispatchEvent(new Event("change"));
-  });
 };
 
 export const setupMRDiff = () => {
-  if (
-    getElementByQuerySelector<HTMLInputElement>('[data-testid="file-by-file"]')
-      ?.checked
-  ) {
+  setupViewedShortcut();
+
+  if (isFileByFileMode()) {
     setupAutoNext();
   } else {
     window.observer?.disconnect();
@@ -115,7 +353,7 @@ export const setupMRDiff = () => {
   getElementByQuerySelector<HTMLInputElement>(
     '[data-testid="file-by-file"]',
   )?.addEventListener("change", (event: Event) => {
-    if (!(event.target as HTMLInputElement).checked) {
+    if ((event.target as HTMLInputElement).checked) {
       setupAutoNext();
     } else {
       window.observer?.disconnect();


### PR DESCRIPTION
Pressing v when viewing all files at once now marks the first unviewed file as viewed and smooth-scrolls the next unviewed file to the top of the screen, in both the new rapid diffs UI and the old Vue diffs UI.

- Suppress GitLab's native v binding (MR_TOGGLE_REVIEW) via a capture-phase listener; it toggles the scroll-tracked "current file" and would otherwise fight our toggle (mark + immediate unmark)
- Pick files by DOM order, never by focus or viewport position: GitLab re-renders silently drop focus, and collapsing a file shifts layout before positions are measured
- Re-resolve the scroll target by stable id/data-path in case Vue replaces the DOM node, with a corrective second scroll if the smooth scroll got stranded by batch loading; the correction yields to any user scrolling and to newer v presses
- Keep the legacy auto-next behavior in one-file-at-a-time mode